### PR TITLE
feat: Up access token secret name to be configurable in GithubApp spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ metadata:
   name: GithubApp-sample
   namespace: team-1
 spec:
-  appId: 
+  appId: 123123
   installId: 12312312
   privateKeySecret: github-app-secret
   accessTokenSecret: github-app-access-token-123123

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It will reconcile a new access token before expiry (1hr).
 Key features:
 - Uses a custom resource `GithubApp` in your destination namespace.
 - Reads `appId`, `installId` and either and `privateKeySecret` or `vaultPrivateKey` defined in a `GithubApp` resource and requests an access token from Github for the Github App.
-  - It stores the access token in a secret `github-app-access-token-{appId}`
+  - It stores the access token in a secret as per `accessTokenSecret`
 - For pulling a GitHub Apps private key, there are 2 options built-in:
   - Using a Kubernetes secret:
     - Use `privateKeySecret` - refers to an existing secret in the namespace which holds the base64 encoded PEM of the Github App's private key.
@@ -93,9 +93,10 @@ metadata:
   name: GithubApp-sample
   namespace: team-1
 spec:
-  appId: 123123
+  appId: 
   installId: 12312312
   privateKeySecret: github-app-secret
+  accessTokenSecret: github-app-access-token-123123
 EOF
 ```
 
@@ -114,6 +115,7 @@ spec:
   appId: 123123
   installId: 12312312
   privateKeySecret: github-app-secret
+  accessTokenSecret: github-app-access-token-123123
   rolloutDeployment:
     labels:
       foo: bar
@@ -133,6 +135,7 @@ metadata:
 spec:
   appId: 123123
   installId: 12312312
+  accessTokenSecret: github-app-access-token-123123
   vaultPrivateKey:
     mountPath: secret
     secretPath: githubapp/123123

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Key features:
   - INSTALL ID
   - EXPIRES AT
   - ERROR
+  - Access Token Secret
 - Events are recorded for:
   - Any error on reconcile for a GithubApp
   - Creation of an access token secret

--- a/api/v1/githubapp_types.go
+++ b/api/v1/githubapp_types.go
@@ -27,6 +27,7 @@ type GithubAppSpec struct {
 	PrivateKeySecret  string                 `json:"privateKeySecret,omitempty"`
 	RolloutDeployment *RolloutDeploymentSpec `json:"rolloutDeployment,omitempty"`
 	VaultPrivateKey   *VaultPrivateKeySpec   `json:"vaultPrivateKey,omitempty"`
+	AccessTokenSecret string                 `json:"accessTokenSecret"`
 }
 
 // GithubAppStatus defines the observed state of GithubApp
@@ -42,6 +43,7 @@ type GithubAppStatus struct {
 
 // GithubApp is the Schema for the githubapps API
 // +kubebuilder:printcolumn:name="App ID",type=string,JSONPath=`.spec.appId`
+// +kubebuilder:printcolumn:name="Access Token Secret",type=string,JSONPath=`.spec.accessTokenSecret`
 // +kubebuilder:printcolumn:name="Install ID",type=string,JSONPath=`.spec.installId`
 // +kubebuilder:printcolumn:name="Expires At",type=string,JSONPath=`.status.expiresAt`
 // +kubebuilder:printcolumn:name="Error",type=string,JSONPath=`.status.error`

--- a/config/crd/bases/githubapp.samir.io_githubapps.yaml
+++ b/config/crd/bases/githubapp.samir.io_githubapps.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .spec.appId
       name: App ID
       type: string
+    - jsonPath: .spec.accessTokenSecret
+      name: Access Token Secret
+      type: string
     - jsonPath: .spec.installId
       name: Install ID
       type: string
@@ -52,6 +55,8 @@ spec:
           spec:
             description: GithubAppSpec defines the desired state of GithubApp
             properties:
+              accessTokenSecret:
+                type: string
               appId:
                 type: integer
               installId:
@@ -83,6 +88,7 @@ spec:
                 - secretPath
                 type: object
             required:
+            - accessTokenSecret
             - appId
             - installId
             type: object

--- a/example.yaml
+++ b/example.yaml
@@ -7,3 +7,4 @@ spec:
   appId: 857468
   installId: 48531286
   privateKeySecret: github-app-secret
+  accessTokenSecret: github-app-access-token-123123

--- a/internal/controller/githubapp_controller.go
+++ b/internal/controller/githubapp_controller.go
@@ -250,7 +250,7 @@ func (r *GithubAppReconciler) checkExpiryAndUpdateAccessToken(ctx context.Contex
 	// Check if the access token secret exists if not reconcile immediately
 	accessTokenSecretKey := client.ObjectKey{
 		Namespace: githubApp.Namespace,
-		Name:      fmt.Sprintf("github-app-access-token-%d", githubApp.Spec.AppId),
+		Name:      githubApp.Spec.AccessTokenSecret,
 	}
 	accessTokenSecret := &corev1.Secret{}
 	if err := r.Get(ctx, accessTokenSecretKey, accessTokenSecret); err != nil {
@@ -659,7 +659,7 @@ func (r *GithubAppReconciler) createOrUpdateAccessToken(ctx context.Context, git
 	}
 
 	// Access token Kubernetes secret name
-	accessTokenSecret := fmt.Sprintf("github-app-access-token-%d", githubApp.Spec.AppId)
+	accessTokenSecret := githubApp.Spec.AccessTokenSecret
 
 	// Access token secret key
 	accessTokenSecretKey := client.ObjectKey{

--- a/internal/controller/test_helpers/test_helpers.go
+++ b/internal/controller/test_helpers/test_helpers.go
@@ -145,6 +145,7 @@ func CreateGitHubAppAndWait(
 			PrivateKeySecret:  privateKeySecret,
 			RolloutDeployment: rolloutDeploymentSpec, // Optionally pass rolloutDeployment
 			VaultPrivateKey:   vaultPrivateKeySpec,   // Optionally pass vaultPrivateKeySpec
+			AccessTokenSecret: acessTokenSecretName,
 		},
 	}
 	gomega.Expect(k8sClient.Create(ctx, &githubApp)).Should(gomega.Succeed())


### PR DESCRIPTION
User will now configure the access token secret name in spec.accessTokenSecret